### PR TITLE
fix build: webpack.validateSchema is not a func

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -28,7 +28,7 @@
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
     "webpack": "2.1.0-beta.22",
-    "webpack-dev-server": "^2.1.0-beta.0"
+    "webpack-dev-server": "2.1.0-beta.9"
   },
   "dependencies": {
     "babel-loader": "^6.2.5",


### PR DESCRIPTION
related to https://github.com/webpack/webpack-dev-server/issues/788